### PR TITLE
Fix monthly reset bug

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -110,7 +110,9 @@ export default function Home() {
       now.getDate(),
     ).getTime();
     const startOfWeek = new Date(
-      now.setDate(now.getDate() - now.getDay() + (now.getDay() === 0 ? -6 : 1)),
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate() - (now.getDay() === 0 ? 6 : now.getDay() - 1),
     ).getTime();
     const startOfMonth = new Date(
       now.getFullYear(),


### PR DESCRIPTION
## Summary
- avoid mutating current date when determining start of week

## Testing
- `next` not installed so `npm run lint` fails